### PR TITLE
for static-server

### DIFF
--- a/example/presentation/example.js
+++ b/example/presentation/example.js
@@ -4,7 +4,7 @@ var PDFController = require("pdf.js-controller");
 var container = document.getElementById("pdf-container");
 var controller = new PDFController({
     container: container,
-    pdfjsDistDir: __dirname + "/node_modules/pdfjs-dist/"
+    pdfjsDistDir: "/node_modules/pdfjs-dist/"
 });
 var PDFURL = "./example.pdf";
 controller.loadDocument(PDFURL).then(initializedEvent).catch(function (error) {


### PR DESCRIPTION
#2 の続き。

static-serverで起動すると、私の環境(Safari)では下記のエラーで状況変わらずとなりました。

```
Failed to load resource: 指定されたホスト名のサーバが見つかりませんでした。
http://node_modules/pdfjs-dist/cmaps/Adobe-Japan1-UCS2.bcmap
```

pdfjsDistDirの値を変更することで日本語も表示されるようになりましたが、fileプロトコルではうまく開けいない状態のままです。
